### PR TITLE
Podman support and various fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN useradd -m admin && \
 RUN pip3 install --upgrade pip setuptools
 
 # Install Python dependencies, including JupyterHub and JupyterLab
-RUN pip3 install --no-cache-dir jupyterhub==5.1.0 jupyterlab python-dotenv jupyterhub-dummyauthenticator batchspawner
+RUN pip3 install --no-cache-dir jupyterhub==5.1.0 jupyterlab python-dotenv batchspawner
 
 # Clean up to reduce image size
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nathanhess/slurm:full-v1.1.0
+FROM docker.io/nathanhess/slurm:full-v1.1.0
 
 # Switch to root user to install additional packages
 USER root

--- a/README.md
+++ b/README.md
@@ -174,3 +174,13 @@ $scancel -f <job-id>
 ```shell
 $scontrol update NodeName=localhost State=RESUME Reason="Manual clear of drain state"
 ```
+
+6. Remove all untracked data files from bind-mounted directories (e.g. `slurm_spool/`)
+
+   ```shell
+   # Dry-run to see what would be deleted
+   git clean -x -d --dry-run
+
+   # Delete untracked files
+   git clean -x -d --force
+   ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sinfo
 
 ### 0. Prerequisites
 
-Docker is required to use for the container. Podman is also possible, but not tested yet.
+Docker is required to use for the container. Podman is also possible.
 
 Prepare a user (i.e. admin) in your host, to mimic the container set up.
 ```shell

--- a/README.md
+++ b/README.md
@@ -62,11 +62,16 @@ sinfo
 Docker is required to use for the container. Podman is also possible.
 
 Prepare a user (i.e. admin) in your host, to mimic the container set up.
+
+> [!NOTE]
+> Creating a user in the host may not be necessary in all cases. For example, when testing the container in a `podman` machine on macOS, not additional user was required on the host (within the VM).
+
 ```shell
 $useradd -m admin && \
     echo "admin:<hashed-password>" | chpasswd && \
     echo "admin ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 ```
+
 This user should be the owner of following folders
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $sudo chown -R admin:admin slurm_spool
 
 ```shell
 $cd brics-jupyter-slurm
-$docker build -t brics_slurm_jupyter .
+$docker build -t brics-jupyter-slurm .
 ```
 
 ### 2. Run JupyterHub without Slurm
@@ -105,7 +105,7 @@ $ssh -L 38024:localhost:38024 -L 8888:localhost:8888 your_user@remote_host
 
 #### Use another shell to access the container to start slurm
 ```shell
-$docker exec -it slurm-jupyter bash
+$docker exec -it jupyter-slurm bash
 $slurmctld
 $slurmd  
 $sinfo
@@ -150,19 +150,19 @@ Caveat: JupyterHub redirecting JupyterNotebook is not working at the moment, so 
 ```shell
 $docker ps 
 CONTAINER ID   IMAGE                        COMMAND                  CREATED        STATUS        PORTS              NAMES
-c1de9a675fe4   brics_slurm_jupyter:latest   "jupyterhub -f /srv/…"   2 hours ago   Up 2 hours   <ports-exposed>   slurm-jupyter
+c1de9a675fe4   brics-jupyter-slurm:latest   "jupyterhub -f /srv/…"   2 hours ago   Up 2 hours   <ports-exposed>   jupyter-slurm
 ```
 Make sure the port-exposed are expected.
 
 2. Check docker logs
 ```shell
-$docker logs -f slurm-jupyter
+$docker logs -f jupyter-slurm
 ```
 
 3. To stop the docker gracefully and clean it up, use:
 ```shell
-$docker stop slurm-jupyter
-$docker rm slurm-jupyter
+$docker stop jupyter-slurm
+$docker rm jupyter-slurm
 ```
 
 4. To clean up the jobs in the queue forcefully, inside the container, use

--- a/jupyter_config/jupyterhub_config.py
+++ b/jupyter_config/jupyterhub_config.py
@@ -5,19 +5,20 @@ c.Authenticator.allowed_users = {'admin'}
 
 # URL config
 c.ConfigurableHTTPProxy.api_url = 'http://0.0.0.0:8018'
-c.JupyterHub.bind_url = 'http://0.0.0.0:38024'
+c.JupyterHub.bind_url = 'http://:38024'
 c.JupyterHub.hub_connect_ip = '0.0.0.0'
 c.JupyterHub.base_url = '/'
 
 # Spawner settings
-c.JupyterHub.spawner_class = 'jupyterhub.spawner.SimpleLocalProcessSpawner'
-c.Spawner.args = ['--notebook-dir=/tmp/admin/notebooks', '--ip=0.0.0.0', '--allow-root']
+c.JupyterHub.spawner_class = 'simple'
+c.Spawner.args = []
 c.Spawner.debug = True
 c.Spawner.default_url = '/lab'
 c.Spawner.ip = '0.0.0.0'
 c.Spawner.notebook_dir = '/tmp/admin/notebooks'
-c.Spawner.start_timeout = 120 
-c.Spawner.http_timeout = 120  
+c.Spawner.start_timeout = 120
+c.Spawner.http_timeout = 120
 
+# Logging
 c.JupyterHub.log_level = 'DEBUG'
-c.JUpyterHub.log_file = '/srv/jupyterhub/jupyterhub.log'
+c.JupyterHub.extra_log_file = '/srv/jupyterhub/jupyterhub.log'

--- a/jupyter_config/jupyterhub_config.py
+++ b/jupyter_config/jupyterhub_config.py
@@ -11,7 +11,7 @@ c.JupyterHub.base_url = '/'
 
 # Spawner settings
 c.JupyterHub.spawner_class = 'simple'
-c.Spawner.args = []
+c.Spawner.args = ['--allow-root']
 c.Spawner.debug = True
 c.Spawner.default_url = '/lab'
 c.Spawner.ip = '0.0.0.0'
@@ -21,4 +21,3 @@ c.Spawner.http_timeout = 120
 
 # Logging
 c.JupyterHub.log_level = 'DEBUG'
-c.JupyterHub.extra_log_file = '/srv/jupyterhub/jupyterhub.log'

--- a/jupyter_config/jupyterhub_config.py
+++ b/jupyter_config/jupyterhub_config.py
@@ -1,24 +1,7 @@
-import os
-import logging
-import sys
-
-from dummyauthenticator import DummyAuthenticator
-
 # Set the authenticator class to DummyAuthenticator for testing
-c.JupyterHub.authenticator_class = DummyAuthenticator
+c.JupyterHub.authenticator_class = 'dummy'
 c.Authenticator.admin_users = {'admin'}
 c.Authenticator.allowed_users = {'admin'}
-c.LocalAuthenticator.create_system_users = True
-
-# Set up logging
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
-
-# Log the final authenticator setup
-logger.info("Using NoPasswordPAMAuthenticator for passwordless access")
-
-# Log the final authenticator setup
-logger.info("Assigned NoPasswordPAMAuthenticator")
 
 # URL config
 c.ConfigurableHTTPProxy.api_url = 'http://0.0.0.0:8018'

--- a/jupyter_config/jupyterhub_config_slurm.py
+++ b/jupyter_config/jupyterhub_config_slurm.py
@@ -2,7 +2,7 @@ import os
 import logging
 import sys
 
-sys.path.append('/usr/local/bin/') 
+sys.path.append('/opt/brics_jupyter/')
 from brics_slurm_spawner import BricsSlurmSpawner
 from brics_token_authenticator import BricsAuthenticator
 

--- a/jupyter_config/jupyterhub_config_slurm.py
+++ b/jupyter_config/jupyterhub_config_slurm.py
@@ -1,3 +1,5 @@
+import sys
+
 sys.path.append('/opt/brics_jupyter/')
 from brics_slurm_spawner import BricsSlurmSpawner
 from brics_token_authenticator import BricsAuthenticator
@@ -33,4 +35,3 @@ c.BricsSlurmSpawner.batch_cancel_cmd = "scancel {job_id}"   # Cancel job
 
 # Logging
 c.JupyterHub.log_level = 'DEBUG'
-c.JupyterHub.extra_log_file = '/srv/jupyterhub/jupyterhub.log'

--- a/jupyter_config/jupyterhub_config_slurm.py
+++ b/jupyter_config/jupyterhub_config_slurm.py
@@ -19,20 +19,17 @@ c.JupyterHub.hub_connect_ip = '0.0.0.0'
 c.JupyterHub.base_url = '/'
 
 # Spawner settings
-spawner = BricsSlurmSpawner()
-spawner.user = type('User', (object,), {'name': 'admin'})() 
 c.JupyterHub.spawner_class = BricsSlurmSpawner
 
 # Configure the spawner's environment and notebook settings
-c.BricsSlurmSpawner.cmd = ['jupyter-lab']
-c.BricsSlurmSpawner.args = ['--notebook-dir=/tmp/admin/notebooks', '--ip=0.0.0.0', '--allow-root']
+c.BricsSlurmSpawner.cmd = ['jupyterhub-singleuser']
+c.BricsSlurmSpawner.args = []
 c.BricsSlurmSpawner.debug = True
 c.BricsSlurmSpawner.default_url = '/lab'
 c.BricsSlurmSpawner.ip = '0.0.0.0'
-c.BricsSlurmSpawner.notebook_dir = '/tmp/admin/notebooks'
-c.BricsSlurmSpawner.start_timeout = 300  
-c.BricsSlurmSpawner.http_timeout = 300  
-c.BricsSlurmSpawner.job_status = ['R']   # Specify the status that indicates running ('R' for Slurm)
+c.BricsSlurmSpawner.notebook_dir = '/tmp/{username}/notebooks'
+c.BricsSlurmSpawner.start_timeout = 300
+c.BricsSlurmSpawner.http_timeout = 300
 
 # Slurm settings
 c.BricsSlurmSpawner.batch_submit_cmd = "sbatch --parsable" # Submit job

--- a/jupyter_config/jupyterhub_config_slurm.py
+++ b/jupyter_config/jupyterhub_config_slurm.py
@@ -35,6 +35,7 @@ c.BricsSlurmSpawner.http_timeout = 300
 c.BricsSlurmSpawner.job_status = ['R']   # Specify the status that indicates running ('R' for Slurm)
 
 # Slurm settings
-c.BricsSlurmSpawner.batch_query_cmd = 'squeue -j {job_id}'  # Query job status
-c.BricsSlurmSpawner.batch_cancel_cmd = 'scancel {job_id}'   # Cancel job
+c.BricsSlurmSpawner.batch_submit_cmd = "sbatch --parsable" # Submit job
+c.BricsSlurmSpawner.batch_query_cmd = "squeue -h -j {job_id} -o '%T %B'"  # Query job status
+c.BricsSlurmSpawner.batch_cancel_cmd = "scancel {job_id}"   # Cancel job
 

--- a/jupyter_config/jupyterhub_config_slurm.py
+++ b/jupyter_config/jupyterhub_config_slurm.py
@@ -1,7 +1,3 @@
-import os
-import logging
-import sys
-
 sys.path.append('/opt/brics_jupyter/')
 from brics_slurm_spawner import BricsSlurmSpawner
 from brics_token_authenticator import BricsAuthenticator
@@ -10,7 +6,6 @@ from brics_token_authenticator import BricsAuthenticator
 c.JupyterHub.authenticator_class = BricsAuthenticator
 c.Authenticator.admin_users = {'admin'}
 c.Authenticator.allowed_users = {'admin'}
-c.LocalAuthenticator.create_system_users = True
 
 # URL config
 c.ConfigurableHTTPProxy.api_url = 'http://0.0.0.0:8018'
@@ -36,3 +31,6 @@ c.BricsSlurmSpawner.batch_submit_cmd = "sbatch --parsable" # Submit job
 c.BricsSlurmSpawner.batch_query_cmd = "squeue -h -j {job_id} -o '%T %B'"  # Query job status
 c.BricsSlurmSpawner.batch_cancel_cmd = "scancel {job_id}"   # Cancel job
 
+# Logging
+c.JupyterHub.log_level = 'DEBUG'
+c.JupyterHub.extra_log_file = '/srv/jupyterhub/jupyterhub.log'

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,22 @@
 #! /bin/bash
+set -euo pipefail
 
+# To use an alternative container engine command, specify as first argument, e.g.
+#   run.sh podman
+# Default with no argument is to use docker
+if (( $# == 0 )); then
+  ENGINE_CMD="docker"
+elif (( $# == 1 )); then
+  ENGINE_CMD="$1"
+else
+  echo "Error: Incorrect number of arguments"
+  echo "Usage: $0 [container engine command]"
+  exit 1
+fi
 
-docker run --name slurm-jupyter \
+set -o xtrace
+
+${ENGINE_CMD} run --name jupyter-slurm \
     --privileged \
     -p 6817:6817 -p 6818:6818 \
     -p 38024:38024   \
@@ -14,7 +29,9 @@ docker run --name slurm-jupyter \
     --mount type=bind,source=$PWD/jupyter_config,target=/srv/jupyterhub \
     --mount type=bind,source=$PWD/jupyter_notebooks,target=/tmp/admin/notebooks \
     --mount type=bind,source=$PWD/jupyter_bin/brics_slurm_spawner.py,target=/usr/local/bin/brics_slurm_spawner.py \
-    brics_slurm_jupyter:latest \
+    brics-jupyter-slurm:latest \
     jupyterhub -f /srv/jupyterhub/jupyterhub_config.py --debug
 
 #   sleep infinity (for debugging)
+
+set +o xtrace

--- a/run.sh
+++ b/run.sh
@@ -1,26 +1,16 @@
 #! /bin/bash
 set -euo pipefail
 
-# To use an alternative container engine command, specify as first argument, e.g.
-#   run.sh podman
-# Default with no argument is to use docker
-if (( $# == 0 )); then
-  ENGINE_CMD="docker"
-elif (( $# == 1 )); then
-  ENGINE_CMD="$1"
-else
-  echo "Error: Incorrect number of arguments"
-  echo "Usage: $0 [container engine command]"
-  exit 1
-fi
+ENGINE_CMD=${CONTAINER_ENGINE_CMD:-docker}
+BIND_IP=${CONTAINER_BIND_IP:-}
 
 set -o xtrace
 
-${ENGINE_CMD} run --name jupyter-slurm \
+${ENGINE_CMD} run --rm --name jupyter-slurm \
     --privileged \
-    -p 6817:6817 -p 6818:6818 \
-    -p 38024:38024   \
-    -p 8888:8888 \
+    -p ${BIND_IP}${BIND_IP:+:}6817:6817 -p ${BIND_IP}${BIND_IP:+:}6818:6818 \
+    -p ${BIND_IP}${BIND_IP:+:}38024:38024 \
+    -p ${BIND_IP}${BIND_IP:+:}8888:8888 \
     --user root \
     --mount type=bind,source=$PWD/slurm_logs,target=/srv/slurm_logs \
     --mount type=bind,source=$PWD/slurm_config/slurm.conf,target=/etc/slurm/slurm.conf \

--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ ${ENGINE_CMD} run --rm --name jupyter-slurm \
     --mount type=bind,source=$PWD/slurm_spool/slurmctld,target=/var/spool/slurmctld \
     --mount type=bind,source=$PWD/jupyter_config,target=/srv/jupyterhub \
     --mount type=bind,source=$PWD/jupyter_notebooks,target=/tmp/admin/notebooks \
-    --mount type=bind,source=$PWD/jupyter_bin/brics_slurm_spawner.py,target=/usr/local/bin/brics_slurm_spawner.py \
+    --mount type=bind,source=$PWD/jupyter_bin/brics_slurm_spawner.py,target=/opt/brics_jupyter/brics_slurm_spawner.py \
     brics-jupyter-slurm:latest \
     jupyterhub -f /srv/jupyterhub/jupyterhub_config.py --debug
 

--- a/run_slurm.sh
+++ b/run_slurm.sh
@@ -18,8 +18,8 @@ ${ENGINE_CMD} run --rm --name jupyter-slurm \
     --mount type=bind,source=$PWD/slurm_spool/slurmctld,target=/var/spool/slurmctld \
     --mount type=bind,source=$PWD/jupyter_config,target=/srv/jupyterhub \
     --mount type=bind,source=$PWD/jupyter_notebooks,target=/tmp/admin/notebooks \
-    --mount type=bind,source=$PWD/jupyter_bin/brics_slurm_spawner.py,target=/usr/local/bin/brics_slurm_spawner.py \
-    --mount type=bind,source=$PWD/jupyter_bin/brics_token_authenticator.py,target=/usr/local/bin/brics_token_authenticator.py \
+    --mount type=bind,source=$PWD/jupyter_bin/brics_slurm_spawner.py,target=/opt/brics_jupyter/brics_slurm_spawner.py \
+    --mount type=bind,source=$PWD/jupyter_bin/brics_token_authenticator.py,target=/opt/brics_jupyter/brics_token_authenticator.py \
     brics-jupyter-slurm:latest \
     jupyterhub -f /srv/jupyterhub/jupyterhub_config_slurm.py 
 

--- a/run_slurm.sh
+++ b/run_slurm.sh
@@ -1,26 +1,16 @@
 #! /bin/bash
 set -euo pipefail
 
-# To use an alternative container engine command, specify as first argument, e.g.
-#   run.sh podman
-# Default with no argument is to use docker
-if (( $# == 0 )); then
-  ENGINE_CMD="docker"
-elif (( $# == 1 )); then
-  ENGINE_CMD="$1"
-else
-  echo "Error: Incorrect number of arguments"
-  echo "Usage: $0 [container engine command]"
-  exit 1
-fi
+ENGINE_CMD=${CONTAINER_ENGINE_CMD:-docker}
+BIND_IP=${CONTAINER_BIND_IP:-}
 
 set -o xtrace
 
-${ENGINE_CMD} run --name jupyter-slurm \
+${ENGINE_CMD} run --rm --name jupyter-slurm \
     --privileged \
-    -p 6817:6817 -p 6818:6818 \
-    -p 38024:38024   \
-    -p 8888:8888 \
+    -p ${BIND_IP}${BIND_IP:+:}6817:6817 -p ${BIND_IP}${BIND_IP:+:}6818:6818 \
+    -p ${BIND_IP}${BIND_IP:+:}38024:38024 \
+    -p ${BIND_IP}${BIND_IP:+:}8888:8888 \
     --user root \
     --mount type=bind,source=$PWD/slurm_logs,target=/srv/slurm_logs \
     --mount type=bind,source=$PWD/slurm_config/slurm.conf,target=/etc/slurm/slurm.conf \

--- a/run_slurm.sh
+++ b/run_slurm.sh
@@ -1,7 +1,22 @@
 #! /bin/bash
+set -euo pipefail
 
+# To use an alternative container engine command, specify as first argument, e.g.
+#   run.sh podman
+# Default with no argument is to use docker
+if (( $# == 0 )); then
+  ENGINE_CMD="docker"
+elif (( $# == 1 )); then
+  ENGINE_CMD="$1"
+else
+  echo "Error: Incorrect number of arguments"
+  echo "Usage: $0 [container engine command]"
+  exit 1
+fi
 
-docker run --name slurm-jupyter \
+set -o xtrace
+
+${ENGINE_CMD} run --name jupyter-slurm \
     --privileged \
     -p 6817:6817 -p 6818:6818 \
     -p 38024:38024   \
@@ -15,7 +30,9 @@ docker run --name slurm-jupyter \
     --mount type=bind,source=$PWD/jupyter_notebooks,target=/tmp/admin/notebooks \
     --mount type=bind,source=$PWD/jupyter_bin/brics_slurm_spawner.py,target=/usr/local/bin/brics_slurm_spawner.py \
     --mount type=bind,source=$PWD/jupyter_bin/brics_token_authenticator.py,target=/usr/local/bin/brics_token_authenticator.py \
-    brics_slurm_jupyter:latest \
+    brics-jupyter-slurm:latest \
     jupyterhub -f /srv/jupyterhub/jupyterhub_config_slurm.py 
-    
+
 #   sleep infinity (for debugging)
+
+set +o xtrace

--- a/slurm_config/slurm.conf
+++ b/slurm_config/slurm.conf
@@ -35,7 +35,7 @@ SlurmctldLogFile=/srv/slurm_logs/slurmctld.log
 SlurmdLogFile=/srv/slurm_logs/slurmd.log
 #
 # COMPUTE NODES
-NodeName=localhost CPUs=2 Sockets=1 CoresPerSocket=2 ThreadsPerCore=1 RealMemory=31700 State=UNKNOWN
+NodeName=localhost CPUs=2 Sockets=1 CoresPerSocket=2 ThreadsPerCore=1 RealMemory=1024 State=UNKNOWN
 PartitionName=debug Nodes=localhost Default=YES MaxTime=INFINITE State=UP
 
 # Authentication
@@ -49,3 +49,4 @@ SlurmdUser=root
 
 KillWait=120    # Increase to give jobs more time to terminate before being forcibly killed
 UnkillableStepTimeout=120  # MailProg=/bin/true
+SlurmdParameters=config_overrides  # Do not set node state to INVALID_REG if configuration does not match available resources


### PR DESCRIPTION
* Enable container engine command (`docker`/`podman`) and bind IP for JupyterHub to be specified as environment variables for run scripts
* Make image tag and container name consistent with repository name in `README.md`
* Fix job spawning issues by
  * Using default `batch_*_cmd` configuration attributes from `SlurmSpawner`
  * Using default `BricsSlurmSpawner.cmd` configuration value from `Spawner`
* Fix `slurmd` starting compute node in `INVALID_REG` state by setting `config_overrides` `slurmd` parameter and reducing resource associated with the node
* Remove dependency on `jupyterhub-dummyauthenticator` pip package (`DummyAuthenticator` is built into JupyterHub)
* Tidy JupyterHub configuration files, remove unneeded and deprecated code and configuration attributes
* Change BriCS Python module bind mount path to under `/opt` since `/usr/local/bin` is for executables
* Explicitly specify container registry (`docker.io`) to avoid `podman build` prompting for registry 