### PR TITLE
Revert changes to run.sh, run_slurm.sh scripts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ BIND_IP=${CONTAINER_BIND_IP:-}
 set -o xtrace
 
 ${ENGINE_CMD} run --rm --name jupyter-slurm \
+    --privileged \
     -p ${BIND_IP}${BIND_IP:+:}38024:38024 \
     --user root \
     --mount type=bind,source=$PWD/slurm_logs,target=/srv/slurm_logs \

--- a/run_slurm.sh
+++ b/run_slurm.sh
@@ -6,7 +6,7 @@ BIND_IP=${CONTAINER_BIND_IP:-}
 
 set -o xtrace
 
-podman run --rm --name jupyter-slurm \
+${ENGINE_CMD} run --rm --name jupyter-slurm \
     --privileged \
     -p ${BIND_IP}${BIND_IP:+:}38024:38024 \
     --user root \


### PR DESCRIPTION
* Restore use of `ENGINE_CMD` env var for command in run_slurm.sh
* Restore `--privileged` flag in run.sh

The `--privileged` flag seems to be necessary to run the container in the Zenith dev VM, likely because it disabled SELinux separation for the container.